### PR TITLE
Kaputten Link auf das PDF-Formular gefixt

### DIFF
--- a/foerder.html
+++ b/foerder.html
@@ -783,7 +783,7 @@ function syncElement (source, parent, selector) {
 
 			<br>
 			<p>
-				Solltest du Probleme mit diesem Formular haben, möchten wir <a href="https://github.com/HerrSpace/CCC-Membership-Form/issues">diese gerne erfahren</a>. Alternativ kannst du <a href="https://www.ccc.de/system/uploads/269/original/Supporterform-de-v5.pdf">diesen PDF Antrag</a> ausfüllen.
+				Solltest du Probleme mit diesem Formular haben, möchten wir <a href="https://github.com/HerrSpace/CCC-Membership-Form/issues">diese gerne erfahren</a>. Alternativ kannst du <a href="https://www.ccc.de/system/uploads/307/original/Supporterform-de-v6.pdf">diesen PDF Antrag</a> ausfüllen.
 			</p>
 		</form>
 	</div>

--- a/foerder.j2
+++ b/foerder.j2
@@ -137,7 +137,7 @@ https://github.com/HerrSpace/CCC-Membership-Form/issues
 
 			<br>
 			<p>
-				Solltest du Probleme mit diesem Formular haben, möchten wir <a href="https://github.com/HerrSpace/CCC-Membership-Form/issues">diese gerne erfahren</a>. Alternativ kannst du <a href="https://www.ccc.de/system/uploads/269/original/Supporterform-de-v5.pdf">diesen PDF Antrag</a> ausfüllen.
+				Solltest du Probleme mit diesem Formular haben, möchten wir <a href="https://github.com/HerrSpace/CCC-Membership-Form/issues">diese gerne erfahren</a>. Alternativ kannst du <a href="https://www.ccc.de/system/uploads/307/original/Supporterform-de-v6.pdf">diesen PDF Antrag</a> ausfüllen.
 			</p>
 		</form>
 	</div>


### PR DESCRIPTION
Keine Ahnung, wieso das noch auf v5 zeigte, aber vorher funktionierte